### PR TITLE
Taking tail parameters from root file

### DIFF
--- a/DQFitter.py
+++ b/DQFitter.py
@@ -9,6 +9,8 @@ from utils.utils_library import ComputeSigToBkg, ComputeSignificance, ComputeAlp
 class DQFitter:
     def __init__(self, fInName, fInputName, fOutPath, minDatasetRange, maxDatasetRange):
         self.fPdfDict          = {}
+        self.tailRootFileName  = "" #NEW
+        self.tailHistName      = "" #NEW
         self.fOutPath          = fOutPath
         self.fFileOutName      = "{}/output__{}_{}.root".format(fOutPath, minDatasetRange, maxDatasetRange)
         self.fFileOut          = TFile(self.fFileOutName, "RECREATE")
@@ -32,11 +34,13 @@ class DQFitter:
     def GetFileOutName(self):
         return self.fFileOutNameNew
 
-    def SetFitConfig(self, pdfDict):
+    def SetFitConfig(self, pdfDict, tailRootFileName, tailHistName):
         '''
         Method set the configuration of the fit
         '''
         self.fPdfDict = pdfDict
+        self.tailRootFileName = tailRootFileName #name of root file used for fixed parameters in the fit (tail parameters)
+        self.tailHistName = tailHistName #name of histogram used for fixed parameters in the fit (tail parameters)
         # Exception to take into account the case in which AnalysisResults.root is used
         if "analysis-same-event-pairing/output" in self.fInputName:
             hlistIn = self.fFileIn.Get("analysis-same-event-pairing/output")
@@ -63,21 +67,38 @@ class DQFitter:
             if not self.fPdfDict["pdf"][i] == "SUM":
                 gROOT.ProcessLineSync(".x ../fit_library/{}Pdf.cxx+".format(self.fPdfDict["pdf"][i]))
         
+        fileTails = TFile(tailRootFileName, "READ")
+        hTails = fileTails.Get(tailHistName) #this histogram contains all tail parameters from the extraction: 1 and 2 are free, the tails come after
+
         for i in range(0, len(self.fPdfDict["pdf"])):
-            parVal = self.fPdfDict["parVal"][i]
-            parLimMin = self.fPdfDict["parLimMin"][i]
-            parLimMax = self.fPdfDict["parLimMax"][i]
+        
             parName = self.fPdfDict["parName"][i]
+            parVal = [0]*len(parName) #define an array for the parValues of the pdf
+            parLimMin = [0]*len(parName)
+            parLimMax = [0]*len(parName)
 
-            if not len(parVal) == len(parLimMin) == len(parLimMax) == len(parName):
-                print("WARNING! Different size if the input parameters in the configuration")
-                print(parVal)
-                print(parLimMin)
-                print(parLimMax)
-                print(parName)
-                exit()
+            if self.fPdfDict["pdfName"][i] == "Jpsi" or self.fPdfDict["pdfName"][i] == "Psi2s": #if the function is a signal shape, parameters are taken from either the cfg or the root
+                for j in range(0, len(parName)):
+                    if j<2: #if the parameter is the mean or the width, it will be taken from the configuration file
+                        parVal[j] = self.fPdfDict["parVal"][i][j]
+                        parLimMin[j] = self.fPdfDict["parLimMin"][i][j]
+                        parLimMax[j] = self.fPdfDict["parLimMax"][i][j]
+                        print(j, parVal[j], parLimMin[j], parLimMax[j])
 
-            if not self.fPdfDict["pdf"][i] == "SUM":
+                    else:  #if it is a tail parameter it will be taken from the root file
+                        parVal[j]= hTails.GetBinContent(j+1) #histogram binning starts from 1
+                        parLimMin[j] = hTails.GetBinContent(j+1)
+                        parLimMax[j] = hTails.GetBinContent(j+1)
+                        print(j, parVal[j], parLimMin[j], parLimMax[j])
+
+                if not len(parVal) == len(parLimMin) == len(parLimMax) == len(parName):
+                    print("WARNING! Different size if the input parameters in the configuration")
+                    print(parVal)
+                    print(parLimMin)
+                    print(parLimMax)
+                    print(parName)
+                    exit()
+
                 # Filling parameter list
                 for j in range(0, len(parVal)):
                     if ("sum" in parName[j]) or ("prod" in parName[j]):
@@ -103,7 +124,62 @@ class DQFitter:
                     nameFunc += ",{}".format(parName[j])
                 nameFunc += ")"
                 self.fRooWorkspace.factory(nameFunc)
-            else:
+
+            elif self.fPdfDict["pdfName"][i] == "Bkg": #if the function is bkg, all parameters are taken from the, but function is built as above
+                parVal = self.fPdfDict["parVal"][i]
+                parLimMin = self.fPdfDict["parLimMin"][i]
+                parLimMax = self.fPdfDict["parLimMax"][i]
+                print("")
+                print(parVal)
+
+                if not len(parVal) == len(parLimMin) == len(parLimMax) == len(parName):
+                    print("WARNING! Different size if the input parameters in the configuration")
+                    print(parVal)
+                    print(parLimMin)
+                    print(parLimMax)
+                    print(parName)
+                    exit()
+
+                # Filling parameter list
+                for j in range(0, len(parVal)):
+                    if ("sum" in parName[j]) or ("prod" in parName[j]):
+                        self.fRooWorkspace.factory("{}".format(parName[j]))
+                        # Replace the exression of the parameter with the name of the parameter
+                        r1 = parName[j].find("::") + 2
+                        r2 = parName[j].find("(", r1)
+                        parName[j] = parName[j][r1:r2]
+                        self.fRooWorkspace.factory("{}[{}]".format(parName[j], parVal[j]))
+                    else:
+                        if (parLimMin[j] == parLimMax[j]):
+                            self.fRooWorkspace.factory("{}[{}]".format(parName[j], parVal[j]))
+                        else:
+                            self.fRooWorkspace.factory("{}[{},{},{}]".format(parName[j], parVal[j], parLimMin[j], parLimMax[j]))
+
+                        self.fParNames.append(parName[j]) # only free parameters will be reported in the histogram of results
+
+                # Define the pdf associating the parametes previously defined
+                nameFunc = self.fPdfDict["pdf"][i]
+                nameFunc += "Pdf::{}Pdf(fMass[{},{}]".format(self.fPdfDict["pdfName"][i], self.fMinDatasetRange, self.fMaxDatasetRange)
+                pdfList.append(self.fPdfDict["pdfName"][i])
+                for j in range(0, len(parVal)):
+                    nameFunc += ",{}".format(parName[j])
+                nameFunc += ")"
+                self.fRooWorkspace.factory(nameFunc)
+
+            else: #if the function is SUM, all parameters are taken from the cfg and the function is built in a different way
+                parVal = self.fPdfDict["parVal"][i]
+                parLimMin = self.fPdfDict["parLimMin"][i]
+                parLimMax = self.fPdfDict["parLimMax"][i]
+                print("")
+                print(parVal)
+                if not len(parVal) == len(parLimMin) == len(parLimMax) == len(parName):
+                    print("WARNING! Different size if the input parameters in the configuration")
+                    print(parVal)
+                    print(parLimMin)
+                    print(parLimMax)
+                    print(parName)
+                    exit()
+                
                 nameFunc = self.fPdfDict["pdf"][i]
                 nameFunc += "::sum("
                 for j in range(0, len(pdfList)):

--- a/analysis/config_analysis_CB2_VWG_NEW_trial.json
+++ b/analysis/config_analysis_CB2_VWG_NEW_trial.json
@@ -1,0 +1,75 @@
+{
+    "input": {
+      "input_file_name":"/Users/mattei/cernbox/JPSI/Psi2S_Jpsi_ratio_run3/data/2024/LHC24_pass7_skimmed_std_assoc/Histograms_AnalysisResults_std_assoc_fDiMuon.root",
+      "input_name": [
+        "Proj_PairsMuonSEPM_matchedMchMid__Pt_0.0_0.5"
+      ],
+      "tailRootFileName":"/Users/mattei/LHC22_pass7_skimmed/MC_tail_extraction/pt_dependence/Pt_0.0_0.5/output__Proj_PairsMuonSEPM_MatchedMchMid_MC__Pt_0.0_0.5_CB2__2.5_3.5.root",
+      "tailHistName":"fit_results_CB2__2.5_3.5_Proj_PairsMuonSEPM_MatchedMchMid_MC__Pt_0.0_0.5",
+      "pdf_dictionary": {
+        "pdf": ["CB2", "CB2", "VWG", "SUM"],
+        "pdfName": ["Jpsi", "Psi2s", "Bkg", "SUM"],
+        "pdfColor": [861, 417, 1],
+        "pdfNameForLegend": ["J/#psi", "#psi(2S)","Background", "Fit"],
+        "pdfStyle": [1, 1, 2],
+        "parVal": [
+          [3.096, 0.75e-01],
+          [3.68, 0.75e-01],
+          [2.04, 0.36, 0.45],
+          [2761000, 45598, 6800000]
+        ],
+        "parLimMin": [
+          [2.90, 6.0e-02],
+          [3.2, 6.0e-02],
+          [-10, -10, -10],
+          [100, 1, 1000]
+        ],
+        "parLimMax": [
+          [3.20, 1.5e-01],
+          [3.9, 1.5e-01],
+          [10, 10, 10],
+          [5000000, 5000000, 9500000]
+        ],
+        "parName": [
+          ["mean_Jpsi", "width_Jpsi", "a_Jpsi", "b_Jpsi", "c_Jpsi", "d_Jpsi"],
+          ["sum::mean_Psi2s(mean_Jpsi,0.584)", "prod::width_Psi2s(width_Jpsi,1.05)", "a_Jpsi", "b_Jpsi", "c_Jpsi", "d_Jpsi"],
+          ["aa", "bb", "cc"],
+          ["sig_Jpsi", "sig_Psi2s", "bkg"]
+        ],
+        "fitRangeMin": [2.1],
+        "fitRangeMax": [4.9],
+        "rebin": 1,
+        "fitMethod": "likelyhood",
+        "doResidualPlot": true,
+        "doPullPlot": true, 
+        "doCorrMatPlot": false,
+        "doAlicePlot": false,
+        "cosmeticsForAlicePlot": {
+          "logScale" : false,
+          "extraTextSize" : 0.035,
+          "extraTextSpacing" : 0.04,
+          "extraTextPos" : [0.55, 0.47],
+          "legendPos" : [0.65, 0.60, 0.85, 0.89]
+        },
+        "sPlot": {
+          "sRun" : false,
+          "sVar" : "fCos2DeltaPhi",
+          "sVarName" : "cos(2#Delta#phi)",
+          "sRangeMin" : -1,
+          "sRangeMax" : 1,
+          "sBins" : 20,
+          "sPars" : ["sig_Upsilon1s", "bkg"]
+        },
+        "parForAlicePlot": ["mean_Jpsi", "width_Jpsi", "sig_Jpsi", "sig_Psi2s", "sOverB_Jpsi", "sgnf_Jpsi", "corrMatrStatus"],
+        "parNameForAlicePlot": ["#mu_{J/#psi}", "#sigma_{J/#psi}", "#it{N}_{J/#psi}", "#it{N}_{#psi(2S)}", "sOverB_Jpsi", "sgnf_Jpsi", "corrMatrStatus"],
+        "text": [
+          [0.20, 0.87, "LHC22o CB2+Pol4Exp, #sqrt{#it{s}} = 13.6 TeV"], 
+          [0.20, 0.80, "2.5 < #it{y} < 4, J/#psi #rightarrow #mu^{+}#mu^{-}"]
+        ]
+      }
+    },
+    "output": {
+      "output_file_name": "/Users/mattei/LHC24_pass7_skimmed/good_runs/NEW_FITTER_TRIAL/pt_dependence/Pt_0.0_0.5",
+      "output_merged_file_name": "multi_trial_CB2_Pol4Exp_MC_tails"
+    }
+  }

--- a/analysis/runDQFitter.py
+++ b/analysis/runDQFitter.py
@@ -34,6 +34,8 @@ def main():
         minFitRanges   = inputCfg["input"]["pdf_dictionary"]["fitRangeMin"]
         maxFitRanges   = inputCfg["input"]["pdf_dictionary"]["fitRangeMax"]
 
+        tailRootFileName = inputCfg["input"]["tailRootFileName"] #NEW
+        tailHistName = inputCfg["input"]["tailHistName"] #NEW
         listOfOutputFileNames = [] # list of output file names
         
         if not path.isdir(outputFileName):
@@ -47,7 +49,7 @@ def main():
                 print(inputFileName)
                 dqFitter = DQFitter(inputFileName, histName, outputFileName, minFitRange, maxFitRange)
                 print(inputCfg["input"]["pdf_dictionary"]["parName"])
-                dqFitter.SetFitConfig(pdfDictionary)
+                dqFitter.SetFitConfig(pdfDictionary, tailRootFileName, tailHistName)
                 dqFitter.SingleFit()
                 listOfOutputFileNames.append(dqFitter.GetFileOutName())
 
@@ -56,7 +58,7 @@ def main():
             listOfOutputFileNamesToMerge = " ".join(listOfOutputFileNames)
             mergingCommand = mergedFileName + listOfOutputFileNamesToMerge
             print(mergingCommand)
-            os.system(f'hadd {mergingCommand}')
+            os.system(f'hadd -f {mergingCommand}') # -f option to overwrite merged file when rerunning the code
             # Delete unmerged files
             for listOfOutputFileName in listOfOutputFileNames:
                 os.system(f'rm {listOfOutputFileName}')

--- a/analysis/runDQFitter_new.py
+++ b/analysis/runDQFitter_new.py
@@ -1,0 +1,105 @@
+from traceback import print_tb
+import yaml
+import json
+import sys
+import argparse
+from array import array
+import os
+from os import path
+import ROOT
+from ROOT import TFile
+sys.path.append('../')
+from DQFitter_new import DQFitter_new
+sys.path.append('../utils')
+from utils_library import DoSystematics, CheckVariables
+
+def main():
+    print('start')
+    parser = argparse.ArgumentParser(description='Arguments to pass')
+    parser.add_argument('cfgFileName', metavar='text', default='config.yml', help='config file name')
+    #parser.add_argument("--do_fit", help="run the single fit", action="store_true")
+    parser.add_argument("--do_fit_fixed_tails", help="run the single fit with tail parameters taken from a root file", action="store_true")
+    args = parser.parse_args()
+    print(args)
+    print('Loading task configuration: ...', end='\r')
+
+    with open(args.cfgFileName, 'r') as jsonCfgFile:
+        inputCfg = json.load(jsonCfgFile)
+    print('Loading task configuration: Done!')
+
+    """
+    if args.do_fit:
+        inputFileName  = inputCfg["input"]["input_file_name"]
+        outputFileName = inputCfg["output"]["output_file_name"]
+        mergedFileName = inputCfg["output"]["output_merged_file_name"]
+        histNames      = inputCfg["input"]["input_name"]
+        minFitRanges   = inputCfg["input"]["pdf_dictionary"]["fitRangeMin"]
+        maxFitRanges   = inputCfg["input"]["pdf_dictionary"]["fitRangeMax"]
+
+        listOfOutputFileNames = [] # list of output file names
+        
+        if not path.isdir(outputFileName):
+            os.system("mkdir -p %s" % (outputFileName))
+        for histName in histNames:
+            for minFitRange, maxFitRange in zip(minFitRanges, maxFitRanges):
+                # Reload configuration file
+                with open(args.cfgFileName, 'r') as jsonCfgFile:
+                    inputCfg = json.load(jsonCfgFile)
+                pdfDictionary  = inputCfg["input"]["pdf_dictionary"]
+                print(inputFileName)
+                dqFitter = DQFitter(inputFileName, histName, outputFileName, minFitRange, maxFitRange)
+                print(inputCfg["input"]["pdf_dictionary"]["parName"])
+                dqFitter.SetFitConfig(pdfDictionary)
+                dqFitter.SingleFit()
+                listOfOutputFileNames.append(dqFitter.GetFileOutName())
+
+        if len(histNames) > 1 or len(minFitRanges) > 1:
+            mergedFileName = f'{outputFileName}/{mergedFileName}.root '
+            listOfOutputFileNamesToMerge = " ".join(listOfOutputFileNames)
+            mergingCommand = mergedFileName + listOfOutputFileNamesToMerge
+            print(mergingCommand)
+            os.system(f'hadd -f {mergingCommand}')
+            # Delete unmerged files
+            for listOfOutputFileName in listOfOutputFileNames:
+                os.system(f'rm {listOfOutputFileName}')
+    """
+
+    if args.do_fit_fixed_tails:
+        inputFileName  = inputCfg["input"]["input_file_name"]
+        outputFileName = inputCfg["output"]["output_file_name"]
+        mergedFileName = inputCfg["output"]["output_merged_file_name"]
+        histNames      = inputCfg["input"]["input_name"]
+        minFitRanges   = inputCfg["input"]["pdf_dictionary"]["fitRangeMin"]
+        maxFitRanges   = inputCfg["input"]["pdf_dictionary"]["fitRangeMax"]
+
+        tailRootFileName = inputCfg["input"]["tailRootFileName"] #NEW
+        tailHistName = inputCfg["input"]["tailHistName"] #NEW
+        listOfOutputFileNames = [] # list of output file names
+        
+        if not path.isdir(outputFileName):
+            os.system("mkdir -p %s" % (outputFileName))
+        for histName in histNames:
+            for minFitRange, maxFitRange in zip(minFitRanges, maxFitRanges):
+                # Reload configuration file
+                with open(args.cfgFileName, 'r') as jsonCfgFile:
+                    inputCfg = json.load(jsonCfgFile)
+                pdfDictionary  = inputCfg["input"]["pdf_dictionary"]
+                print(inputFileName)
+                dqFitter = DQFitter_new(inputFileName, histName, outputFileName, minFitRange, maxFitRange)
+                print(inputCfg["input"]["pdf_dictionary"]["parName"])
+                dqFitter.SetFitConfig(pdfDictionary, tailRootFileName, tailHistName)
+                dqFitter.SingleFit()
+                listOfOutputFileNames.append(dqFitter.GetFileOutName())
+
+        if len(histNames) > 1 or len(minFitRanges) > 1:
+            mergedFileName = f'{outputFileName}/{mergedFileName}.root '
+            listOfOutputFileNamesToMerge = " ".join(listOfOutputFileNames)
+            mergingCommand = mergedFileName + listOfOutputFileNamesToMerge
+            print(mergingCommand)
+            os.system(f'hadd -f {mergingCommand}')
+            # Delete unmerged files
+            for listOfOutputFileName in listOfOutputFileNames:
+                os.system(f'rm {listOfOutputFileName}')
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
The DQFitter takes the tail parameters from a root file, which is specified in the configuration. All free parameters are set in the config.  To be integrated with previous version