### PR TITLE
Adding option to have free tails

### DIFF
--- a/DQFitter.py
+++ b/DQFitter.py
@@ -39,8 +39,13 @@ class DQFitter:
         Method set the configuration of the fit
         '''
         self.fPdfDict = pdfDict
-        self.tailRootFileName = tailRootFileName #name of root file used for fixed parameters in the fit (tail parameters)
-        self.tailHistName = tailHistName #name of histogram used for fixed parameters in the fit (tail parameters)
+        if tailRootFileName is not None and tailHistName is not None:
+            self.tailFile = ROOT.TFile(tailRootFileName, "READ") #name of root file used for fixed parameters in the fit (tail parameters)
+            self.tailHist = self.tailFile.Get(tailHistName) #name of histogram used for fixed parameters in the fit (tail parameters)
+        else:
+            self.tailFile = None
+            self.tailHist = None
+
         # Exception to take into account the case in which AnalysisResults.root is used
         if "analysis-same-event-pairing/output" in self.fInputName:
             hlistIn = self.fFileIn.Get("analysis-same-event-pairing/output")
@@ -67,8 +72,9 @@ class DQFitter:
             if not self.fPdfDict["pdf"][i] == "SUM":
                 gROOT.ProcessLineSync(".x ../fit_library/{}Pdf.cxx+".format(self.fPdfDict["pdf"][i]))
         
-        fileTails = TFile(tailRootFileName, "READ")
-        hTails = fileTails.Get(tailHistName) #this histogram contains all tail parameters from the extraction: 1 and 2 are free, the tails come after
+        if tailRootFileName is not None and tailHistName is not None:
+            fileTails = TFile(tailRootFileName, "READ")
+            hTails = fileTails.Get(tailHistName) #this histogram contains all tail parameters from the extraction: 1 and 2 are free, the tails come after
 
         for i in range(0, len(self.fPdfDict["pdf"])):
         
@@ -137,6 +143,7 @@ class DQFitter:
                         nameFunc += ","
                 nameFunc += ")"
                 self.fRooWorkspace.factory(nameFunc)
+
 
     def CheckSignalTails(self, fitRangeMin, fitRangeMax):
         '''

--- a/DQFitter.py
+++ b/DQFitter.py
@@ -6,7 +6,7 @@ from ROOT import gPad, gROOT
 from utils.plot_library import DoResidualPlot, DoPullPlot, DoCorrMatPlot, DoAlicePlot, LoadStyle
 from utils.utils_library import ComputeSigToBkg, ComputeSignificance, ComputeAlpha
 
-class DQFitter:
+class DQFitter_mod:
     def __init__(self, fInName, fInputName, fOutPath, minDatasetRange, maxDatasetRange):
         self.fPdfDict          = {}
         self.tailRootFileName  = "" #NEW
@@ -39,8 +39,15 @@ class DQFitter:
         Method set the configuration of the fit
         '''
         self.fPdfDict = pdfDict
-        self.tailRootFileName = tailRootFileName #name of root file used for fixed parameters in the fit (tail parameters)
-        self.tailHistName = tailHistName #name of histogram used for fixed parameters in the fit (tail parameters)
+        if tailRootFileName is not None and tailHistName is not None:
+            self.tailFile = ROOT.TFile(tailRootFileName, "READ")
+            self.tailHist = self.tailFile.Get(tailHistName)
+        else:
+            self.tailFile = None
+            self.tailHist = None
+
+        """ self.tailRootFileName = tailRootFileName #name of root file used for fixed parameters in the fit (tail parameters)
+        self.tailHistName = tailHistName #name of histogram used for fixed parameters in the fit (tail parameters) """
         # Exception to take into account the case in which AnalysisResults.root is used
         if "analysis-same-event-pairing/output" in self.fInputName:
             hlistIn = self.fFileIn.Get("analysis-same-event-pairing/output")
@@ -67,8 +74,9 @@ class DQFitter:
             if not self.fPdfDict["pdf"][i] == "SUM":
                 gROOT.ProcessLineSync(".x ../fit_library/{}Pdf.cxx+".format(self.fPdfDict["pdf"][i]))
         
-        fileTails = TFile(tailRootFileName, "READ")
-        hTails = fileTails.Get(tailHistName) #this histogram contains all tail parameters from the extraction: 1 and 2 are free, the tails come after
+        if tailRootFileName is not None and tailHistName is not None:
+            fileTails = TFile(tailRootFileName, "READ")
+            hTails = fileTails.Get(tailHistName) #this histogram contains all tail parameters from the extraction: 1 and 2 are free, the tails come after
 
         for i in range(0, len(self.fPdfDict["pdf"])):
         
@@ -137,6 +145,7 @@ class DQFitter:
                         nameFunc += ","
                 nameFunc += ")"
                 self.fRooWorkspace.factory(nameFunc)
+
 
     def CheckSignalTails(self, fitRangeMin, fitRangeMax):
         '''

--- a/DQFitter.py
+++ b/DQFitter.py
@@ -9,8 +9,8 @@ from utils.utils_library import ComputeSigToBkg, ComputeSignificance, ComputeAlp
 class DQFitter:
     def __init__(self, fInName, fInputName, fOutPath, minDatasetRange, maxDatasetRange):
         self.fPdfDict          = {}
-        self.tailRootFileName  = "" #NEW
-        self.tailHistName      = "" #NEW
+        self.tailRootFileName  = "" 
+        self.tailHistName      = "" 
         self.fOutPath          = fOutPath
         self.fFileOutName      = "{}/output__{}_{}.root".format(fOutPath, minDatasetRange, maxDatasetRange)
         self.fFileOut          = TFile(self.fFileOutName, "RECREATE")

--- a/DQFitter.py
+++ b/DQFitter.py
@@ -6,7 +6,7 @@ from ROOT import gPad, gROOT
 from utils.plot_library import DoResidualPlot, DoPullPlot, DoCorrMatPlot, DoAlicePlot, LoadStyle
 from utils.utils_library import ComputeSigToBkg, ComputeSignificance, ComputeAlpha
 
-class DQFitter_mod:
+class DQFitter:
     def __init__(self, fInName, fInputName, fOutPath, minDatasetRange, maxDatasetRange):
         self.fPdfDict          = {}
         self.tailRootFileName  = "" #NEW

--- a/analysis/config_analysis_CB2_VWG_singleFit.json
+++ b/analysis/config_analysis_CB2_VWG_singleFit.json
@@ -1,0 +1,69 @@
+{
+  "input": {
+    "input_file_name":"/Users/saragaretti/cernbox/JPsi_Psi2S_ratio/data/LHC23_pass4_pTcut_1GeV_new/Train_321538/mergedHistograms_sub.root",
+    "input_name": [
+      "Mass_BkgSub_Int_ME"
+    ],
+      "tailRootFileName": null,
+      "tailHistNames": [
+        null
+      ],
+      "pdf_dictionary": {
+        "pdf": ["CB2", "CB2", "VWG", "SUM"],
+        "pdfName": ["Jpsi", "Psi2s", "Bkg", "SUM"],
+        "pdfColor": [861, 417, 1],
+        "pdfNameForLegend": ["J/#psi", "#psi(2S)","Background", "Fit"],
+        "pdfStyle": [1, 1, 2],
+        "parVal": [
+          [3.096, 0.735e-01, 0.9930, 4.2750, 2.5501, 23.1],
+          [3.68, 0.735e-01, 0.9930, 4.2750, 2.5501, 23.1],
+          [2.3626, 0.4406, 0.5959],
+          [2.3e6, 1.8e4, 1.5e6]
+        ],
+        "parLimMin": [
+          [2.90, 6.0e-02, 0.2, 2.0, 0.0, -10],
+          [3.2, 6.0e-02, 0.2, 2.0, 0.0, -10],
+          [-10, -10, -10],
+          [100, 1, 1000]
+        ],
+        "parLimMax": [
+          [3.20, 1.5e-01, 1.5, 10.0, 4.0, 100.0],
+          [3.9, 1.5e-01, 1.5, 10.0, 4.0, 100.0],
+          [10, 10, 10],
+          [2e9, 8e5, 2e9]
+        ],
+        "parName": [
+          ["mean_Jpsi", "width_Jpsi", "a_Jpsi", "b_Jpsi", "c_Jpsi", "d_Jpsi"],
+          ["sum::mean_Psi2s(mean_Jpsi,0.584)", "prod::width_Psi2s(width_Jpsi,1.05)","a_Jpsi", "b_Jpsi", "c_Jpsi", "d_Jpsi"],
+          ["aa", "bb", "cc"],
+          ["sig_Jpsi", "sig_Psi2s", "bkg"]
+        ],
+        "fitRangeMin": [2.0],
+        "fitRangeMax": [5.0],
+        "rebin": 1,
+        "fitMethod": "likelyhood",
+        "doResidualPlot": true,
+        "doPullPlot": true, 
+        "doCorrMatPlot": false,
+        "doAlicePlot": true,
+        "cosmeticsForAlicePlot": {
+          "logScale" : true,
+          "extraTextSize" : 0.025,
+          "extraTextSpacing" : 0.04,
+          "extraTextPos" : [0.77, 0.85],
+          "legendPos" : [0.58, 0.60, 0.75, 0.89]
+        },
+        "parForAlicePlot": ["mean_Jpsi", "width_Jpsi", "sig_Jpsi", "sig_Psi2s", "sOverB_Jpsi", "sgnf_Jpsi", "corrMatrStatus"],
+        "parNameForAlicePlot": ["#mu_{J/#psi}", "#sigma_{J/#psi}", "#it{N}_{J/#psi}", "#it{N}_{#psi(2S)}", "sOverB_Jpsi", "sgnf_Jpsi", "corrMatrStatus"],
+        "text": [
+          [0.20, 0.91, "LHC23 CB2+VWG, #sqrt{#it{s_{NN}}} = 5.36 TeV"], 
+          [0.20, 0.84, "2.5 < #it{y} < 4, J/#psi #rightarrow #mu^{+}#mu^{-}"],
+          [0.30, 0.77, "(0-90)%"]
+        ]
+      }
+    },
+    "output": {
+      "output_file_name": "/Users/saragaretti/dq_fitter_tails/analysis/outputout_0.7/",
+      "output_merged_file_name": "multi_trial_CB2_VWG"
+    }
+  }

--- a/analysis/runDQFitter.py
+++ b/analysis/runDQFitter.py
@@ -34,7 +34,7 @@ def main():
         minFitRanges   = inputCfg["input"]["pdf_dictionary"]["fitRangeMin"]
         maxFitRanges   = inputCfg["input"]["pdf_dictionary"]["fitRangeMax"]
 
-        if "tailRootFileName" in inputCfg["input"] and "tailHistNames" in inputCfg["input"]: #NEW
+        if "tailRootFileName" in inputCfg["input"] and "tailHistNames" in inputCfg["input"]:
             tailRootFileName = inputCfg["input"]["tailRootFileName"] 
             tailHistNames = inputCfg["input"]["tailHistNames"] 
         #listOfOutputFileNames = [] # list of output file names
@@ -42,7 +42,7 @@ def main():
         if not path.isdir(outputFileName):
             os.system("mkdir -p %s" % (outputFileName))
         
-        if "tailRootFileName" in inputCfg["input"] and "tailHistNames" in inputCfg["input"]: #NEW
+        if "tailRootFileName" in inputCfg["input"] and "tailHistNames" in inputCfg["input"]:
             tailRootFileName = inputCfg["input"]["tailRootFileName"] 
             tailHistNames = inputCfg["input"]["tailHistNames"] 
             for histName in histNames:
@@ -53,7 +53,7 @@ def main():
                         with open(args.cfgFileName, 'r') as jsonCfgFile:
                             inputCfg = json.load(jsonCfgFile)
                         pdfDictionary  = inputCfg["input"]["pdf_dictionary"]
-                        print("PDF Dictionary content:", pdfDictionary) #mod
+                        print("PDF Dictionary content:", pdfDictionary)
                         print(inputFileName)
                         dqFitter = DQFitter(inputFileName, histName, outputFileName, minFitRange, maxFitRange)
                         print(inputCfg["input"]["pdf_dictionary"]["parName"])
@@ -85,7 +85,7 @@ def main():
                     with open(args.cfgFileName, 'r') as jsonCfgFile:
                         inputCfg = json.load(jsonCfgFile)
                     pdfDictionary  = inputCfg["input"]["pdf_dictionary"]
-                    print("PDF Dictionary content:", pdfDictionary) #mod
+                    print("PDF Dictionary content:", pdfDictionary)
                     tailRootFileName = inputCfg["input"].get("tailRootFileName", None)
                     tailHistName = inputCfg["input"].get("tailHistNames", [None])[0]
                     print(inputFileName)

--- a/analysis/runDQFitter.py
+++ b/analysis/runDQFitter.py
@@ -34,41 +34,77 @@ def main():
         minFitRanges   = inputCfg["input"]["pdf_dictionary"]["fitRangeMin"]
         maxFitRanges   = inputCfg["input"]["pdf_dictionary"]["fitRangeMax"]
 
-        tailRootFileName = inputCfg["input"]["tailRootFileName"] 
-        tailHistNames = inputCfg["input"]["tailHistNames"] 
+        if "tailRootFileName" in inputCfg["input"] and "tailHistNames" in inputCfg["input"]: #NEW
+            tailRootFileName = inputCfg["input"]["tailRootFileName"] 
+            tailHistNames = inputCfg["input"]["tailHistNames"] 
         #listOfOutputFileNames = [] # list of output file names
         
         if not path.isdir(outputFileName):
             os.system("mkdir -p %s" % (outputFileName))
-        for histName in histNames:
-            for tailHistName in tailHistNames: #looping over different histograms contaoining different sets of tail parameters
-                listOfOutputFileNames = [] # list of output file names
+        
+        if "tailRootFileName" in inputCfg["input"] and "tailHistNames" in inputCfg["input"]: #NEW
+            tailRootFileName = inputCfg["input"]["tailRootFileName"] 
+            tailHistNames = inputCfg["input"]["tailHistNames"] 
+            for histName in histNames:
+                for tailHistName in tailHistNames: #looping over different histograms contaoining different sets of tail parameters
+                    listOfOutputFileNames = [] # list of output file names
+                    for minFitRange, maxFitRange in zip(minFitRanges, maxFitRanges):
+                        # Reload configuration file
+                        with open(args.cfgFileName, 'r') as jsonCfgFile:
+                            inputCfg = json.load(jsonCfgFile)
+                        pdfDictionary  = inputCfg["input"]["pdf_dictionary"]
+                        print("PDF Dictionary content:", pdfDictionary) #mod
+                        print(inputFileName)
+                        dqFitter = DQFitter(inputFileName, histName, outputFileName, minFitRange, maxFitRange)
+                        print(inputCfg["input"]["pdf_dictionary"]["parName"])
+                        dqFitter.SetFitConfig(pdfDictionary, tailRootFileName, tailHistName) #using each tail set at a time
+                        dqFitter.SingleFit()
+                        listOfOutputFileNames.append(dqFitter.GetFileOutName())
+                    
+                    #Creating a different merged file for each set of tails for a given histogram, containing the 3 fit types
+                    #if len(histNames) > 1 or len(minFitRanges) > 1:
+                    if len(minFitRanges) > 1: 
+                        if "MC" in tailHistName:
+                            mergedFileName_full = f'{outputFileName}/{mergedFileName}_MC_tails.root '
+                        else:
+                            mergedFileName_full = f'{outputFileName}/{mergedFileName}_data_tails.root '
+                        listOfOutputFileNamesToMerge = " ".join(listOfOutputFileNames)
+                        mergingCommand = mergedFileName_full + listOfOutputFileNamesToMerge
+                        print(mergingCommand)
+                        os.system(f'hadd -f {mergingCommand}') # -f option to overwrite merged file when rerunning the code
+                        # Delete unmerged files
+                        for listOfOutputFileName in listOfOutputFileNames:
+                            os.system(f'rm {listOfOutputFileName}')
+
+        #If "tailRootFileName": null, "tailHistNames": [null] in jsonCfgFile, the fit is peformed for one set of tails
+        else: #NEW
+            listOfOutputFileNames = [] # list of output file names
+            for histName in histNames:
                 for minFitRange, maxFitRange in zip(minFitRanges, maxFitRanges):
                     # Reload configuration file
                     with open(args.cfgFileName, 'r') as jsonCfgFile:
                         inputCfg = json.load(jsonCfgFile)
                     pdfDictionary  = inputCfg["input"]["pdf_dictionary"]
+                    print("PDF Dictionary content:", pdfDictionary) #mod
+                    tailRootFileName = inputCfg["input"].get("tailRootFileName", None)
+                    tailHistName = inputCfg["input"].get("tailHistNames", [None])[0]
                     print(inputFileName)
                     dqFitter = DQFitter(inputFileName, histName, outputFileName, minFitRange, maxFitRange)
                     print(inputCfg["input"]["pdf_dictionary"]["parName"])
-                    dqFitter.SetFitConfig(pdfDictionary, tailRootFileName, tailHistName) #using each tail set at a time
+                    dqFitter.SetFitConfig(pdfDictionary, tailRootFileName, tailHistName)
                     dqFitter.SingleFit()
                     listOfOutputFileNames.append(dqFitter.GetFileOutName())
-                
-                #Creating a different merged file for each set of tails for a given histogram, containing the 3 fit types
-                #if len(histNames) > 1 or len(minFitRanges) > 1:
-                if len(minFitRanges) > 1: 
-                    if "MC" in tailHistName:
-                        mergedFileName_full = f'{outputFileName}/{mergedFileName}_MC_tails.root '
-                    else:
-                        mergedFileName_full = f'{outputFileName}/{mergedFileName}_data_tails.root '
-                    listOfOutputFileNamesToMerge = " ".join(listOfOutputFileNames)
-                    mergingCommand = mergedFileName_full + listOfOutputFileNamesToMerge
-                    print(mergingCommand)
-                    os.system(f'hadd -f {mergingCommand}') # -f option to overwrite merged file when rerunning the code
-                    # Delete unmerged files
-                    for listOfOutputFileName in listOfOutputFileNames:
-                        os.system(f'rm {listOfOutputFileName}')
+
+            if len(histNames) > 1 or len(minFitRanges) > 1:
+                mergedFileName = f'{outputFileName}/{mergedFileName}.root '
+                listOfOutputFileNamesToMerge = " ".join(listOfOutputFileNames)
+                mergingCommand = mergedFileName + listOfOutputFileNamesToMerge
+                print(mergingCommand)
+                os.system(f'hadd {mergingCommand}')
+                # Delete unmerged files
+                for listOfOutputFileName in listOfOutputFileNames:
+                    os.system(f'rm {listOfOutputFileName}')
+
 
 if __name__ == '__main__':
     main()

--- a/analysis/runDQFitter.py
+++ b/analysis/runDQFitter.py
@@ -9,7 +9,7 @@ from os import path
 import ROOT
 from ROOT import TFile
 sys.path.append('../')
-from DQFitter import DQFitter
+from DQFitter_test import DQFitter
 sys.path.append('../utils')
 from utils_library import DoSystematics, CheckVariables
 
@@ -77,7 +77,7 @@ def main():
                             os.system(f'rm {listOfOutputFileName}')
 
         #If "tailRootFileName": null, "tailHistNames": [null] in jsonCfgFile, the fit is peformed for one set of tails
-        else: #NEW
+        else:
             listOfOutputFileNames = [] # list of output file names
             for histName in histNames:
                 for minFitRange, maxFitRange in zip(minFitRanges, maxFitRanges):
@@ -95,15 +95,21 @@ def main():
                     dqFitter.SingleFit()
                     listOfOutputFileNames.append(dqFitter.GetFileOutName())
 
-            if len(histNames) > 1 or len(minFitRanges) > 1:
-                mergedFileName = f'{outputFileName}/{mergedFileName}.root '
-                listOfOutputFileNamesToMerge = " ".join(listOfOutputFileNames)
-                mergingCommand = mergedFileName + listOfOutputFileNamesToMerge
-                print(mergingCommand)
-                os.system(f'hadd {mergingCommand}')
-                # Delete unmerged files
-                for listOfOutputFileName in listOfOutputFileNames:
-                    os.system(f'rm {listOfOutputFileName}')
+                    #Creating a different merged file for each set of tails for a given histogram, containing the 3 fit types
+                    #if len(histNames) > 1 or len(minFitRanges) > 1:
+                    if len(minFitRanges) > 1: 
+                        if "MC" in tailHistName:
+                            mergedFileName = f'{outputFileName}/{mergedFileName}_MC_tails.root '
+                        else:
+                            mergedFileName = f'{outputFileName}/{mergedFileName}_data_tails.root '
+                        listOfOutputFileNamesToMerge = " ".join(listOfOutputFileNames)
+                        mergingCommand = mergedFileName + listOfOutputFileNamesToMerge
+                        print(mergingCommand)
+                        os.system(f'hadd -f {mergingCommand}') # -f option to overwrite merged file when rerunning the code
+                        # Delete unmerged files
+                        for listOfOutputFileName in listOfOutputFileNames:
+                            os.system(f'rm {listOfOutputFileName}')
+            
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
runDQFitter.py and DQFitter.py have been modified to include the case where "tailRootFileName": null, "tailHistNames":[null], so when we want to perform a fit without tails parameters in input. 
A configuration example file is also provided under the name "config_analysis_CB2_VWG_singleFit.json"